### PR TITLE
Fixing an apparent typo in process_humaneval.py

### DIFF
--- a/WizardCoder/src/process_humaneval.py
+++ b/WizardCoder/src/process_humaneval.py
@@ -51,7 +51,7 @@ for code_file in tqdm(files, total=len(files)):
                     print("================\n")
                 # print(completion)
             if "__name__ == \"__main__\"" in completion:
-                next_line = completion.index('if __name__ == "__main__":')
+                next_line = completion.index('__name__ == "__main__"')
                 completion = completion[:next_line].strip()
                 # print(completion)
             


### PR DESCRIPTION
When the condition triggers for the string "__name__ == \"__main__\"" (a rare case apparently) the reference code looks for an index of a different string. It leads to a crash.

The proposed correction fixes the reference to get the index of the same string.